### PR TITLE
Additional format options

### DIFF
--- a/videojs.vast.js
+++ b/videojs.vast.js
@@ -16,7 +16,8 @@
 
   defaults = {
     skip: 5, // negative disables
-    vidFormats: ['video/mp4', 'video/webm', 'video/ogv']
+    vidFormats: ['video/mp4', 'video/webm', 'video/ogv'],
+    formatMap: {'video/x-mp4': 'video/mp4'}
   },
 
   vastPlugin = function(options) {
@@ -215,6 +216,7 @@
       // get a list of files with unique formats
       for (i = 0; i < media_files.length; i++) {
         format = media_files[i].mimeType;
+        format = settings.formatMap[format] || format;
 
         if (settings.vidFormats.indexOf(format) >= 0) {
           if(sourcesByFormat[format] === undefined) {


### PR DESCRIPTION
Two changes:
- Enable video formats as an option. I have left the default unchanged. Making this change so we can enable flv ads (as seen [here](https://github.com/guardian/frontend/blob/f0f4712731ea4681ad7ddd770ce94a1ad5050364/common/app/assets/javascripts/bootstraps/media.js#L346))
- Format mapping to enable treatment of one mime-type as another. Making this change as some ad networks give bizarre custom mime-types like video/x-mp4 for plain video/mp4.
