### PR TITLE
Fix the path of the videojs ads plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,7 +26,7 @@ var gruntConfig = {
       helpers: helpers,
       vendor: [
         "http://vjs.zencdn.net/4.4.3/video.js",
-        "lib/videojs-contrib-ads/video.ads.js",
+        "lib/videojs-contrib-ads/videojs.ads.js",
         "lib/vast-client.js"
       ]
     }


### PR DESCRIPTION
Tests are failing because of a bad path in the Gruntfile; The jasmine
configuration has an incorrect path for the ads plugin. Fix by adding
missing 'js'.
