### PR TITLE
Switch prerolls between content changes support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "videojs-vast-plugin",
+  "name": "videojs-vast",
   "version": "0.2.1",
   "homepage": "https://github.com/theonion/videojs-vast-plugin",
   "authors": [

--- a/videojs.vast.js
+++ b/videojs.vast.js
@@ -23,6 +23,22 @@
 
     // return vast plugin
     return {
+      skip: function(skip) {
+        if (skip === undefined) {
+          return settings.skip;
+        } else {
+          settings.skip = skip;
+        }
+      },
+
+      url: function(url) {
+        if (url === undefined) {
+          return settings.url;
+        } else {
+          settings.url = url;
+        }
+      },
+
       createSourceObjects: function (media_files) {
         var sourcesByFormat = {}, i, j, tech;
         var techOrder = player.options().techOrder;

--- a/videojs.vast.js
+++ b/videojs.vast.js
@@ -299,7 +299,7 @@
 
     player.on('contentupdate', function(){
       // videojs-ads triggers this when src changes
-      player.vast.getContent(settings.url);
+      player.vast.getContent();
     });
 
     player.on('readyforpreroll', function() {
@@ -314,7 +314,7 @@
 
     // make an ads request immediately so we're ready when the viewer hits "play"
     if (player.currentSrc()) {
-      player.vast.getContent(settings.url);
+      player.vast.getContent();
     }
 
     // return player to allow this plugin to be chained


### PR DESCRIPTION
- Vast.getContent No Longer Accepts Arguments Fix
- Added getter/setter player.vast.url() and player.vast.skip() functions so that you can change the settings between content changes so you can do something like this:
```
function changeVideo(player, video, adTag) {
  player.vast.url(adTag);
  player.vast.skip(parseInt(Math.random() * 5));
  player.poster(video.poster);
  player.src(video.src);
}
```
- The package is currently registered at bower.io as "videojs-vast". I've renamed the name in the bower.json file to match this.