### PR TITLE
VideoJS 5 Support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,8 +29,8 @@
     "lib"
   ],
   "dependencies": {
-    "videojs": "4.4.3",
+    "videojs": "5.2.1",
     "vast-client-js": "http://github.com/theonion/vast-client-js.git#a0529f00c96f5961c08ab0011df19fd124828e87",
-    "videojs-contrib-ads": "0.5.0"
+    "videojs-contrib-ads": "https://github.com/videojs/videojs-contrib-ads/tree/vjs-5-upgrade"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -29,8 +29,8 @@
     "lib"
   ],
   "dependencies": {
-    "videojs": "5.2.1",
+    "videojs": "5.4.3",
     "vast-client-js": "http://github.com/theonion/vast-client-js.git#a0529f00c96f5961c08ab0011df19fd124828e87",
-    "videojs-contrib-ads": "https://github.com/videojs/videojs-contrib-ads/tree/vjs-5-upgrade"
+    "videojs-contrib-ads": "3.1.1"
   }
 }

--- a/example.html
+++ b/example.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Video.js VAST Example</title>
 
-  <link href="http://vjs.zencdn.net/4.7.1/video-js.css" rel="stylesheet">
+  <link href="http://vjs.zencdn.net/5.2.1/video-js.css" rel="stylesheet">
   <link href="lib/videojs-contrib-ads/videojs.ads.css" rel="stylesheet" type="text/css">
   <link href="videojs.vast.css" rel="stylesheet" type="text/css">
 
@@ -22,7 +22,7 @@
     }
   </style>
   <!--[if lt IE 9]><script src="lib/es5.js"></script><![endif]-->
-  <script src="http://vjs.zencdn.net/4.7.1/video.js"></script>
+  <script src="http://vjs.zencdn.net/5.2.1/video.js"></script>
   <script src="lib/videojs-contrib-ads/videojs.ads.js"></script>
 
   <script src="lib/vast-client.js"></script>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,7 +8,7 @@ module.exports = function(config) {
 
     files: [
       'bower_components/vast-client-js/vast-client.js',
-      'bower_components/videojs/dist/video-js/video.js',
+      'bower_components/videojs/dist/video.js',
       'bower_components/videojs-contrib-ads/src/videojs.ads.js',
       'videojs.vast.js',
       'spec/VastPluginSpec.js'

--- a/lib/videojs-contrib-ads/videojs.ads.js
+++ b/lib/videojs-contrib-ads/videojs.ads.js
@@ -3,7 +3,7 @@
  *
  * Common code to support ad integrations.
  */
-(function(window, document, vjs, undefined) {
+(function(window, document, videojs, undefined) {
 "use strict";
 
 var
@@ -79,29 +79,21 @@ var
   },
 
   /**
-   * Runs the callback at the next available opportunity.
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/window.setImmediate
+   * Defer an action until the call stack is clear.
+   *
+   * @param {Function} callback
    */
-  setImmediate = function(callback) {
-    return (
-      window.setImmediate ||
-      window.requestAnimationFrame ||
-      window.mozRequestAnimationFrame ||
-      window.webkitRequestAnimationFrame ||
-      window.setTimeout
-    )(callback, 0);
+  defer = function(callback) {
+    return window.setTimeout(callback, 1);
   },
 
   /**
-   * Clears a callback previously registered with `setImmediate`.
+   * Aborts a previously deferred action.
+   *
    * @param {id} id The identifier of the callback to abort
    */
-  clearImmediate = function(id) {
-    return (window.clearImmediate ||
-            window.cancelAnimationFrame ||
-            window.webkitCancelAnimationFrame ||
-            window.mozCancelAnimationFrame ||
-            window.clearTimeout)(id);
+  undefer = function(id) {
+    return window.clearTimeout(id);
   },
 
   /**
@@ -118,15 +110,21 @@ var
       // another cancellation is already in flight, so do nothing
       return;
     }
-
-    player.ads.cancelPlayTimeout = setImmediate(function() {
-
+    player.ads.cancelPlayTimeout = defer(function() {
       // deregister the cancel timeout so subsequent cancels are scheduled
       player.ads.cancelPlayTimeout = null;
 
+      // pause playback so ads can be handled.
       if (!player.paused()) {
         player.pause();
       }
+
+      // add a contentplayback handler to resume playback when ads finish.
+      player.one('contentplayback', function() {
+        if (player.paused()) {
+          player.play();
+        }
+      });
     });
   },
 
@@ -140,7 +138,12 @@ var
   getPlayerSnapshot = function(player) {
     var
       tech = player.el().querySelector('.vjs-tech'),
+      tracks = player.remoteTextTracks ? player.remoteTextTracks() : [],
+      track,
+      i,
+      suppressedTracks = [],
       snapshot = {
+        ended: player.ended(),
         src: player.currentSrc(),
         currentTime: player.currentTime(),
         type: player.currentType()
@@ -148,7 +151,19 @@ var
 
     if (tech) {
       snapshot.nativePoster = tech.poster;
+      snapshot.style = tech.getAttribute('style');
     }
+
+    i = tracks.length;
+    while (i--) {
+      track = tracks[i];
+      suppressedTracks.push({
+        track: track,
+        mode: track.mode
+      });
+      track.mode = 'disabled';
+    }
+    snapshot.suppressedTracks = suppressedTracks;
 
     return snapshot;
   },
@@ -179,33 +194,86 @@ var
       // the number of remaining attempts to restore the snapshot
       attempts = 20,
 
+      suppressedTracks = snapshot.suppressedTracks,
+      trackSnapshot,
+      restoreTracks =  function() {
+        var i = suppressedTracks.length;
+        while (i--) {
+          trackSnapshot = suppressedTracks[i];
+          trackSnapshot.track.mode = trackSnapshot.mode;
+        }
+      },
+
       // finish restoring the playback state
       resume = function() {
+        var
+          ended = false,
+          updateEnded = function() {
+            ended = true;
+          };
         player.currentTime(snapshot.currentTime);
-        //If this wasn't a postroll resume
-        if (!player.ended()) {
+
+        // Resume playback if this wasn't a postroll
+        if (!snapshot.ended) {
           player.play();
+        } else {
+          // On iOS 8.1, the "ended" event will not fire if you seek
+          // directly to the end of a video. To make that behavior
+          // consistent with the standard, fire a synthetic event if
+          // "ended" does not fire within 250ms. Note that the ended
+          // event should occur whether the browser actually has data
+          // available for that position
+          // (https://html.spec.whatwg.org/multipage/embedded-content.html#seeking),
+          // so it should not be necessary to wait for the seek to
+          // indicate completion.
+          player.ads.resumeEndedTimeout = window.setTimeout(function() {
+            if (!ended) {
+              player.play();
+            }
+            player.off('ended', updateEnded);
+            player.ads.resumeEndedTimeout = null;
+          }, 250);
+          player.on('ended', updateEnded);
+
+          // Need to clear the resume/ended timeout on dispose. If it fires
+          // after a player is disposed, an error will be thrown!
+          player.on('dispose', function() {
+            window.clearTimeout(player.ads.resumeEndedTimeout);
+          });
         }
       },
 
       // determine if the video element has loaded enough of the snapshot source
       // to be ready to apply the rest of the state
       tryToResume = function() {
+        if (tech.readyState > 1) {
+          // some browsers and media aren't "seekable".
+          // readyState greater than 1 allows for seeking without exceptions
+          return resume();
+        }
+
         if (tech.seekable === undefined) {
           // if the tech doesn't expose the seekable time ranges, try to
           // resume playback immediately
-          resume();
-          return;
+          return resume();
         }
+
         if (tech.seekable.length > 0) {
           // if some period of the video is seekable, resume playback
-          resume();
-          return;
+          return resume();
         }
 
         // delay a bit and then check again unless we're out of attempts
         if (attempts--) {
-          setTimeout(tryToResume, 50);
+          window.setTimeout(tryToResume, 50);
+        } else {
+          (function() {
+            try {
+              resume();
+            } catch(e) {
+              videojs.log.warn('Failed to resume the content after an advertisement', e);
+            }
+          })();
         }
       },
 
@@ -215,6 +283,11 @@ var
 
     if (snapshot.nativePoster) {
       tech.poster = snapshot.nativePoster;
+    }
+
+    if ('style' in snapshot) {
+      // overwrite all css style properties to restore state precisely
+      tech.setAttribute('style', snapshot.style || '');
     }
 
     // Determine whether the player needs to be restored to its state
@@ -235,13 +308,18 @@ var
     }
 
     if (srcChanged) {
+      // on ios7, fiddling with textTracks too early will cause safari to crash
+      player.one('contentloadedmetadata', restoreTracks);
+
       // if the src changed for ad playback, reset it
       player.src({ src: snapshot.src, type: snapshot.type });
       // safari requires a call to `load` to pick up a changed source
       player.load();
       // and then resume from the snapshots time once the original src has loaded
-      player.one('loadedmetadata', tryToResume);
-    } else if (!player.ended()) {
+      player.one('contentcanplay', tryToResume);
+    } else if (!player.ended() || !snapshot.ended) {
+      // if we didn't change the src, just restore the tracks
+      restoreTracks();
       // the src didn't change and this wasn't a postroll
       // just resume playback at the current time.
       player.play();
@@ -279,6 +357,10 @@ var
     // the standard timeout.
     prerollTimeout: 100,
 
+    // maximum amount of time in ms to wait for the ad implementation to start
+    // linear ad mode after `contentended` has fired.
+    postrollTimeout: 100,
+
     // when truthy, instructs the plugin to output additional information about
     // plugin state to the video.js log. On most devices, the video.js log is
     // the same as the developer console.
@@ -294,35 +376,139 @@ var
 
       fsmHandler;
 
+    // prefix all video element events during ad playback
+    // if the video element emits ad-related events directly,
+    // plugins that aren't ad-aware will break. prefixing allows
+    // plugins that wish to handle ad events to do so while
+    // avoiding the complexity for common usage
+    (function() {
+      var
+        videoEvents = videojs.getComponent('Html5').Events,
+        i,
+        returnTrue = function() { return true; },
+        triggerEvent = function(type, event) {
+          // pretend we called stopImmediatePropagation because we want the native
+          // element events to continue propagating
+          event.isImmediatePropagationStopped = returnTrue;
+          event.cancelBubble = true;
+          event.isPropagationStopped = returnTrue;
+          player.trigger({
+            type: type + event.type,
+            state: player.ads.state,
+            originalEvent: event
+          });
+        },
+        redispatch = function(event) {
+          if (player.ads.state === 'ad-playback') {
+            triggerEvent('ad', event);
+          } else if (player.ads.state === 'content-playback' && event.type === 'ended') {
+            triggerEvent('content', event);
+          } else if (player.ads.state === 'content-resuming') {
+            if (player.ads.snapshot) {
+              // the video element was recycled for ad playback
+              if (player.currentSrc() !== player.ads.snapshot.src) {
+                if (event.type === 'loadstart') {
+                  return;
+                }
+                return triggerEvent('content', event);
+
+              // we ended playing postrolls and the video itself
+              // the content src is back in place
+              } else if (player.ads.snapshot.ended) {
+                if ((event.type === 'pause' ||
+                    event.type === 'ended')) {
+                  // after loading a video, the natural state is to not be started
+                  // in this case, it actually has, so, we do it manually
+                  player.addClass('vjs-has-started');
+                  // let `pause` and `ended` events through, naturally
+                  return;
+                }
+                // prefix all other events in content-resuming with `content`
+                return triggerEvent('content', event);
+              }
+            }
+            if (event.type !== 'playing') {
+              triggerEvent('content', event);
+            }
+          }
+        };
+
+      //Add video.js specific events
+      videoEvents.push('firstplay');
+      videoEvents.push('loadedalldata');
+
+      i = videoEvents.length;
+      while (i--) {
+        player.on(videoEvents[i], redispatch);
+      }
+      return redispatch;
+    })();
+
+    // We now auto-play when an ad gets loaded if we're playing ads in the same video element as the content.
+    // The problem is that in IE11, we cannot play in addurationchange but in iOS8, we cannot play from adcanplay.
+    // This will allow ad-integrations from needing to do this themselves.
+    player.on(['addurationchange', 'adcanplay'], function() {
+      var snapshot = player.ads.snapshot;
+      if (player.currentSrc() === snapshot.src) {
+        return;  // do nothing
+      }
+
+      player.play();
+    });
+
     // replace the ad initializer with the ad namespace
     player.ads = {
       state: 'content-set',
 
+      // Call this when an ad response has been received and there are
+      // linear ads ready to be played.
       startLinearAdMode: function() {
-        player.trigger('adstart');
+        if (player.ads.state !== 'ad-playback') {
+          player.trigger('adstart');
+        }
       },
 
+      // Call this when a linear ad pod has finished playing.
       endLinearAdMode: function() {
-        player.trigger('adend');
+        if (player.ads.state === 'ad-playback') {
+          player.trigger('adend');
+        }
+      },
+
+      // Call this when an ad response has been received but there are no
+      // linear ads to be played (i.e. no ads available, or overlays).
+      // This has no effect if we are already in a linear ad mode.  Always
+      // use endLinearAdMode() to exit from linear ad-playback state.
+      skipLinearAdMode: function() {
+        if (player.ads.state !== 'ad-playback') {
+          player.trigger('adskip');
+        }
       }
     };
 
     fsmHandler = function(event) {
-
       // Ad Playback State Machine
       var
         fsm = {
           'content-set': {
             events: {
+              'adscanceled': function() {
+                this.state = 'content-playback';
+              },
               'adsready': function() {
                 this.state = 'ads-ready';
               },
               'play': function() {
                 this.state = 'ads-ready?';
                 cancelContentPlay(player);
-
                 // remove the poster so it doesn't flash between videos
                 removeNativePoster(player);
+              },
+              'adserror': function() {
+                this.state = 'content-playback';
+              },
+              'adskip': function() {
+                this.state = 'content-playback';
               }
             }
           },
@@ -331,6 +517,12 @@ var
               'play': function() {
                 this.state = 'preroll?';
                 cancelContentPlay(player);
+              },
+              'adskip': function() {
+                this.state = 'content-playback';
+              },
+              'adserror': function() {
+                this.state = 'content-playback';
               }
             }
           },
@@ -338,22 +530,15 @@ var
             enter: function() {
               // change class to show that we're waiting on ads
               player.el().className += ' vjs-ad-loading';
-
               // schedule an adtimeout event to fire if we waited too long
-              player.ads.timeout = window.setTimeout(function() {
+              player.ads.adTimeoutTimeout = window.setTimeout(function() {
                 player.trigger('adtimeout');
               }, settings.prerollTimeout);
-
               // signal to ad plugin that it's their opportunity to play a preroll
               player.trigger('readyforpreroll');
-
             },
             leave: function() {
-              window.clearTimeout(player.ads.timeout);
-
-              clearImmediate(player.ads.cancelPlayTimeout);
-              player.ads.cancelPlayTimeout = null;
-
+              window.clearTimeout(player.ads.adTimeoutTimeout);
               removeClass(player.el(), 'vjs-ad-loading');
             },
             events: {
@@ -362,52 +547,47 @@ var
               },
               'adstart': function() {
                 this.state = 'ad-playback';
-                player.el().className += ' vjs-ad-playing';
+              },
+              'adskip': function() {
+                this.state = 'content-playback';
               },
               'adtimeout': function() {
                 this.state = 'content-playback';
-                player.play();
+              },
+              'adserror': function() {
+                this.state = 'content-playback';
               }
             }
           },
           'ads-ready?': {
             enter: function() {
               player.el().className += ' vjs-ad-loading';
-              player.ads.timeout = window.setTimeout(function() {
+              player.ads.adTimeoutTimeout = window.setTimeout(function() {
                 player.trigger('adtimeout');
               }, settings.timeout);
             },
             leave: function() {
-              window.clearTimeout(player.ads.timeout);
+              window.clearTimeout(player.ads.adTimeoutTimeout);
               removeClass(player.el(), 'vjs-ad-loading');
             },
             events: {
               'play': function() {
                 cancelContentPlay(player);
               },
+              'adscanceled': function() {
+                this.state = 'content-playback';
+              },
               'adsready': function() {
                 this.state = 'preroll?';
               },
-              'adtimeout': function() {
-                this.state = 'ad-timeout-playback';
-              }
-            }
-          },
-          'ad-timeout-playback': {
-            events: {
-              'adsready': function() {
-                if (player.paused()) {
-                  this.state = 'ads-ready';
-                } else {
-                  this.state = 'preroll?';
-                }
+              'adskip': function() {
+                this.state = 'content-playback';
               },
-              'contentupdate': function() {
-                if (player.paused()) {
-                  this.state = 'content-set';
-                } else {
-                  this.state = 'ads-ready?';
-                }
+              'adtimeout': function() {
+                this.state = 'content-playback';
+              },
+              'adserror': function() {
+                this.state = 'content-playback';
               }
             }
           },
@@ -416,27 +596,127 @@ var
               // capture current player state snapshot (playing, currentTime, src)
               this.snapshot = getPlayerSnapshot(player);
 
-              // remove the poster so it doesn't flash between videos
+              // add css to the element to indicate and ad is playing.
+              player.el().className += ' vjs-ad-playing';
+
+              // remove the poster so it doesn't flash between ads
               removeNativePoster(player);
+
+              // We no longer need to supress play events once an ad is playing.
+              // Clear it if we were.
+              if (player.ads.cancelPlayTimeout) {
+                undefer(player.ads.cancelPlayTimeout);
+                player.ads.cancelPlayTimeout = null;
+              }
             },
             leave: function() {
               removeClass(player.el(), 'vjs-ad-playing');
               restorePlayerSnapshot(player, this.snapshot);
+              // trigger 'adend' as a consistent notification
+              // event that we're exiting ad-playback.
+              if (player.ads.triggerevent !== 'adend') {
+                player.trigger('adend');
+              }
             },
             events: {
               'adend': function() {
+                this.state = 'content-resuming';
+              },
+              'adserror': function() {
+                this.state = 'content-resuming';
+              }
+            }
+          },
+          'content-resuming': {
+            enter: function() {
+              if (this.snapshot.ended) {
+                window.clearTimeout(player.ads._fireEndedTimeout);
+                // in some cases, ads are played in a swf or another video element
+                // so we do not get an ended event in this state automatically.
+                // If we don't get an ended event we can use, we need to trigger
+                // one ourselves or else we won't actually ever end the current video.
+                player.ads._fireEndedTimeout = window.setTimeout(function() {
+                  player.trigger('ended');
+                }, 1000);
+              }
+            },
+            leave: function() {
+              window.clearTimeout(player.ads._fireEndedTimeout);
+            },
+            events: {
+              'contentupdate': function() {
+                this.state = 'content-set';
+              },
+              contentresumed: function() {
+                this.state = 'content-playback';
+              },
+              'playing': function() {
+                this.state = 'content-playback';
+              },
+              'ended': function() {
                 this.state = 'content-playback';
               }
             }
           },
-          'content-playback': {
+          'postroll?': {
+            enter: function() {
+              this.snapshot = getPlayerSnapshot(player);
+
+              player.el().className += ' vjs-ad-loading';
+
+              player.ads.adTimeoutTimeout = window.setTimeout(function() {
+                player.trigger('adtimeout');
+              }, settings.postrollTimeout);
+            },
+            leave: function() {
+              window.clearTimeout(player.ads.adTimeoutTimeout);
+              removeClass(player.el(), 'vjs-ad-loading');
+            },
             events: {
               'adstart': function() {
                 this.state = 'ad-playback';
-                player.el().className += ' vjs-ad-playing';
-
-                // remove the poster so it doesn't flash between videos
-                removeNativePoster(player);
+              },
+              'adskip': function() {
+                this.state = 'content-resuming';
+                defer(function() {
+                  player.trigger('ended');
+                });
+              },
+              'adtimeout': function() {
+                this.state = 'content-resuming';
+                defer(function() {
+                  player.trigger('ended');
+                });
+              },
+              'adserror': function() {
+                this.state = 'content-resuming';
+                defer(function() {
+                  player.trigger('ended');
+                });
+              }
+            }
+          },
+          'content-playback': {
+            enter: function() {
+              // make sure that any cancelPlayTimeout is cleared
+              if (player.ads.cancelPlayTimeout) {
+                undefer(player.ads.cancelPlayTimeout);
+                player.ads.cancelPlayTimeout = null;
+              }
+              // this will cause content to start if a user initiated
+              // 'play' event was canceled earlier.
+              player.trigger({
+                type: 'contentplayback',
+                triggerevent: player.ads.triggerevent
+              });
+            },
+            events: {
+              // in the case of a timeout, adsready might come in late.
+              'adsready': function() {
+                player.trigger('readyforpreroll');
+              },
+              'adstart': function() {
+                this.state = 'ad-playback';
               },
               'contentupdate': function() {
                 if (player.paused()) {
@@ -444,25 +724,33 @@ var
                 } else {
                   this.state = 'ads-ready?';
                 }
+              },
+              'contentended': function() {
+                this.state = 'postroll?';
               }
             }
           }
         };
 
       (function(state) {
-
         var noop = function() {};
 
         // process the current event with a noop default handler
-        (fsm[state].events[event.type] || noop).apply(player.ads);
+        ((fsm[state].events || {})[event.type] || noop).apply(player.ads);
 
-        // execute leave/enter callbacks if present
+        // check whether the state has changed
         if (state !== player.ads.state) {
+
+          // record the event that caused the state transition
+          player.ads.triggerevent = event.type;
+
+          // execute leave/enter callbacks if present
           (fsm[state].leave || noop).apply(player.ads);
           (fsm[player.ads.state].enter || noop).apply(player.ads);
 
+          // output debug logging
           if (settings.debug) {
-            videojs.log('ads', state + ' -> ' + player.ads.state);
+            videojs.log('ads', player.ads.triggerevent + ' triggered: ' + state + ' -> ' + player.ads.state);
           }
         }
 
@@ -471,22 +759,29 @@ var
     };
 
     // register for the events we're interested in
-    on(player, vjs.Html5.Events.concat([
+    on(player, videojs.getComponent('Html5').Events.concat([
       // events emitted by ad plugin
       'adtimeout',
       'contentupdate',
+      'contentplaying',
+      'contentended',
+      'contentresumed',
+
       // events emitted by third party ad implementors
       'adsready',
+      'adserror',
+      'adscanceled',
       'adstart',  // startLinearAdMode()
-      'adend'     // endLinearAdMode()
+      'adend',    // endLinearAdMode()
+      'adskip'    // skipLinearAdMode()
     ]), fsmHandler);
-    
+
     // keep track of the current content source
     // if you want to change the src of the video without triggering
     // the ad workflow to restart, you can update this variable before
     // modifying the player's source
     player.ads.contentSrc = player.currentSrc();
-    
+
     // implement 'contentupdate' event.
     (function(){
       var
@@ -508,7 +803,7 @@ var
       // loadstart reliably indicates a new src has been set
       player.on('loadstart', checkSrc);
       // check immediately in case we missed the loadstart
-      setImmediate(checkSrc);
+      defer(checkSrc);
     })();
 
     // kick off the fsm
@@ -520,6 +815,6 @@ var
   };
 
   // register the ad plugin framework
-  vjs.plugin('ads', adFramework);
+  videojs.plugin('ads', adFramework);
 
 })(window, document, videojs);

--- a/spec/VastPluginSpec.js
+++ b/spec/VastPluginSpec.js
@@ -135,7 +135,7 @@ describe('videojs.vast plugin', function() {
         player.el().insertBefore(player.vast.blocker, player.controlBar.el());
 
         player.vast.tearDown();
-        expect(player.off).toHaveBeenCalledWith("ended", jasmine.any(Function));
+        expect(player.off).toHaveBeenCalledWith("adended", jasmine.any(Function));
         expect(player.ads.endLinearAdMode).toHaveBeenCalled();
       });
 
@@ -167,7 +167,7 @@ describe('videojs.vast plugin', function() {
       it("should end the ad", function() {
         spyOn(player, "one");
         player.vast.preroll();
-        expect(player.one).toHaveBeenCalledWith("ended", jasmine.any(Function));
+        expect(player.one).toHaveBeenCalledWith("adended", jasmine.any(Function));
       });
 
     });

--- a/spec/VastPluginSpec.js
+++ b/spec/VastPluginSpec.js
@@ -12,12 +12,12 @@ describe('videojs.vast plugin', function() {
       video.src = "http://vjs.zencdn.net/v/oceans.mp4";
       video.setAttribute = "controls";
       document.body.appendChild(video);
-      isHtmlSupported = videojs.Html5.isSupported;
+      isHtmlSupported = videojs.getComponent('Html5').isSupported;
       if (/phantomjs/gi.test(window.navigator.userAgent)) {
         // PhantomJS doesn't have a video element implementation
         // force support here so that the HTML5 tech is still used during
         // command-line test runs
-        videojs.Html5.isSupported = function() {
+        videojs.getComponent('Html5').isSupported = function() {
           return true;
         };
 
@@ -43,7 +43,7 @@ describe('videojs.vast plugin', function() {
 
   afterEach(function() {
     player.dispose();
-    videojs.Html5.isSupported = isHtmlSupported;
+    videojs.getComponent('Html5').isSupported = isHtmlSupported;
     window.clearImmediate = oldClearImmediate;
   });
 
@@ -165,7 +165,7 @@ describe('videojs.vast plugin', function() {
       });
 
       it("should end the ad", function() {
-        spyOn(player, "one");        
+        spyOn(player, "one");
         player.vast.preroll();
         expect(player.one).toHaveBeenCalledWith("ended", jasmine.any(Function));
       });

--- a/videojs.vast.js
+++ b/videojs.vast.js
@@ -28,7 +28,7 @@
         var techOrder = player.options().techOrder;
         for (i = 0, j = techOrder.length; i < j; i++) {
           var techName = techOrder[i].charAt(0).toUpperCase() + techOrder[i].slice(1);
-          tech = window.videojs[techName];
+          tech = vjs.getComponent(techName);
 
           // Check if the current tech is defined before continuing
           if (!tech) {

--- a/videojs.vast.js
+++ b/videojs.vast.js
@@ -16,7 +16,8 @@
 
   defaults = {
     // seconds before skip button shows, negative values to disable skip button altogether
-    skip: 5
+    skip: 5,
+    useVASTSkip: false
   },
 
   Vast = function (player, settings) {
@@ -92,6 +93,12 @@
                     }
 
                     player.vastTracker = new vast.tracker(ad, creative);
+
+                    if (settings.useVASTSkip === true) {
+                      if (creative.skipDelay) {
+                        settings.skip = creative.skipDelay;
+                      }
+                    }
 
                     foundCreative = true;
                   }

--- a/videojs.vast.js
+++ b/videojs.vast.js
@@ -35,25 +35,19 @@
             continue;
           }
 
-          // Check if the browser supports this technology
-          if (tech.isSupported()) {
-            // Loop through each source object
-            for (var a = 0, b = media_files.length; a < b; a++) {
-              var media_file = media_files[a];
-              var source = {type:media_file.mimeType, src:media_file.fileURL};
-              // Check if source can be played with this technology
-              if (tech.canPlaySource(source)) {
-                if (sourcesByFormat[techOrder[i]] === undefined) {
-                  sourcesByFormat[techOrder[i]] = [];
-                }
-                sourcesByFormat[techOrder[i]].push({
-                  type:media_file.mimeType,
-                  src: media_file.fileURL,
-                  width: media_file.width,
-                  height: media_file.height
-                });
-              }
+          // Loop through each source object
+          for (var a = 0, b = media_files.length; a < b; a++) {
+            var media_file = media_files[a];
+            var source = {type:media_file.mimeType, src:media_file.fileURL};
+            if (sourcesByFormat[techOrder[i]] === undefined) {
+              sourcesByFormat[techOrder[i]] = [];
             }
+            sourcesByFormat[techOrder[i]].push({
+              type:media_file.mimeType,
+              src: media_file.fileURL,
+              width: media_file.width,
+              height: media_file.height
+            });
           }
         }
         // Create sources in preferred format order
@@ -145,17 +139,17 @@
               // Inform ad server we couldn't play the media file for this ad
               vast.util.track(player.vastTracker.ad.errorURLTemplates, {ERRORCODE: 405});
               errorOccurred = true;
-              player.trigger('ended');
+              player.trigger('adended');
             };
 
         player.on('canplay', canplayFn);
-        player.on('timeupdate', timeupdateFn);
+        player.on('adtimeupdate', timeupdateFn);
         player.on('pause', pauseFn);
         player.on('error', errorFn);
 
         player.one('vast-preroll-removed', function() {
           player.off('canplay', canplayFn);
-          player.off('timeupdate', timeupdateFn);
+          player.off('adtimeupdate', timeupdateFn);
           player.off('pause', pauseFn);
           player.off('error', errorFn);
           if (!errorOccurred) {
@@ -210,7 +204,7 @@
         player.vast.skipButton = skipButton;
         player.el().appendChild(skipButton);
 
-        player.on("timeupdate", player.vast.timeupdate);
+        player.on("adtimeupdate", player.vast.timeupdate);
 
         skipButton.onclick = function(e) {
           if((' ' + player.vast.skipButton.className + ' ').indexOf(' enabled ') >= 0) {
@@ -226,7 +220,7 @@
 
         player.vast.setupEvents();
 
-        player.one('ended', player.vast.tearDown);
+        player.one('adended', player.vast.tearDown);
 
         player.trigger('vast-preroll-ready');
       },
@@ -237,8 +231,8 @@
         player.vast.blocker.parentNode.removeChild(player.vast.blocker);
 
         // remove vast-specific events
-        player.off('timeupdate', player.vast.timeupdate);
-        player.off('ended', player.vast.tearDown);
+        player.off('adtimeupdate', player.vast.timeupdate);
+        player.off('adended', player.vast.tearDown);
 
         // end ad mode
         player.ads.endLinearAdMode();

--- a/videojs.vast.js
+++ b/videojs.vast.js
@@ -35,19 +35,25 @@
             continue;
           }
 
-          // Loop through each source object
-          for (var a = 0, b = media_files.length; a < b; a++) {
-            var media_file = media_files[a];
-            var source = {type:media_file.mimeType, src:media_file.fileURL};
-            if (sourcesByFormat[techOrder[i]] === undefined) {
-              sourcesByFormat[techOrder[i]] = [];
+          // Check if the browser supports this technology
+          if (tech.isSupported()) {
+            // Loop through each source object
+            for (var a = 0, b = media_files.length; a < b; a++) {
+              var media_file = media_files[a];
+              var source = {type:media_file.mimeType, src:media_file.fileURL};
+              // Check if source can be played with this technology
+              if (tech.canPlaySource(source)) {
+                if (sourcesByFormat[techOrder[i]] === undefined) {
+                  sourcesByFormat[techOrder[i]] = [];
+                }
+                sourcesByFormat[techOrder[i]].push({
+                  type:media_file.mimeType,
+                  src: media_file.fileURL,
+                  width: media_file.width,
+                  height: media_file.height
+                });
+              }
             }
-            sourcesByFormat[techOrder[i]].push({
-              type:media_file.mimeType,
-              src: media_file.fileURL,
-              width: media_file.width,
-              height: media_file.height
-            });
           }
         }
         // Create sources in preferred format order


### PR DESCRIPTION
This updates allows VAST support to be used with VideoJS version 5. Some method/property checks for the `tech` object were removed (no longer exist?) and the event triggers from the ad plugin have been changed in their respective projects.
