### PR TITLE
Fix incorret main property in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "videojs-vast-plugin",
   "version": "0.2.1",
   "description": "A VAST plugin for VideoJS",
-  "main": "vast.video.js",
+  "main": "videojs.vast.js",
   "directories": {
     "test": "test"
   },
@@ -22,7 +22,6 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-env": "~0.4.1",
     "grunt-simple-mocha": "~0.4.0",
-
     "karma": "^0.12.24",
     "grunt-karma": "~0.9.0",
     "karma-coverage": "~0.2.5",
@@ -30,7 +29,6 @@
     "karma-sauce-launcher": "~0.2.10",
     "karma-phantomjs-launcher": "~0.1.4",
     "grunt-karma-coveralls": "2.5.1",
-    
     "lodash": "~2.4.1",
     "wd": "~0.2.12"
   },


### PR DESCRIPTION
For some reason the main property was set to an unexistant file: vast.video.js
Set proper main property to reference: videojs.vast.js
