### PR TITLE
Fix Mute/Unmute event names

### DIFF
--- a/lib/vast-client.js
+++ b/lib/vast-client.js
@@ -1112,7 +1112,7 @@
 
                     VASTTracker.prototype.setMuted = function(muted) {
                         if (this.muted !== muted) {
-                            this.track(muted ? "muted" : "unmuted");
+                            this.track(muted ? "mute" : "unmute");
                         }
                         return this.muted = muted;
                     };


### PR DESCRIPTION
As per the bottom of p. 32 of the VAST 3.0 spec and the top of p. 56 of the VAST 4.0 spec, the actual tracking event names are not **muted/unmuted** but **mute/unmute**

VAST 3.0 spec: https://www.iab.com/wp-content/uploads/2015/06/VASTv3_0.pdf
VAST 4.0 spec: https://www.iab.com/wp-content/uploads/2016/04/VAST4.0_Updated_April_2016.pdf